### PR TITLE
Switch from apt to apt-get to remove warning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:14-buster-slim as build-frontend
 
-RUN apt update && \
-    apt upgrade -y
+RUN apt-get update && \
+    apt-get upgrade -y
 
 COPY package.json ./
 COPY yarn.lock ./


### PR DESCRIPTION
The usage of apt in script results in warnings, with switching the last usages of apt to apt-get, we remove the warnings.