### PR TITLE
Remove default values from warehouse transaction

### DIFF
--- a/app/src/components/admin-page/create-warehouse-transaction-modal.vue
+++ b/app/src/components/admin-page/create-warehouse-transaction-modal.vue
@@ -45,6 +45,7 @@
                                         v-model="warehouseTransaction.pricePerItem"
                                         label="Price per item"
                                         suffix="€"
+                                        placeholder="0.00"
                                         :rules="moneyRules"
                                         @keydown="validateAndSave"
                                     />
@@ -55,6 +56,7 @@
                                         v-model="warehouseTransaction.depositPerItem"
                                         label="Deposit per item"
                                         suffix="€"
+                                        placeholder="0.00"
                                         :rules="moneyRules"
                                         @keydown="validateAndSave"
                                     />
@@ -122,9 +124,9 @@ export default {
             defaultWarehouseTransaction: {
                 productID: '',
                 userID: '',
-                quantity: 0,
-                pricePerItem: 0.00,
-                depositPerItem: 0.00,
+                quantity: null,
+                pricePerItem: null,
+                depositPerItem: null,
                 withCrate: false,
             },
             selectRules: [

--- a/app/src/components/admin-page/edit-product-modal.vue
+++ b/app/src/components/admin-page/edit-product-modal.vue
@@ -28,6 +28,7 @@
                                         v-model="editProduct.price"
                                         label="Price"
                                         suffix="€"
+                                        placeholder="0.00"
                                         :rules="numberRules"
                                         @keydown="validateAndSave"
                                     />
@@ -38,6 +39,7 @@
                                         v-model="editProduct.bottleDeposit"
                                         label="Deposit"
                                         suffix="€"
+                                        placeholder="0.00"
                                         :rules="numberRules"
                                         @keydown="validateAndSave"
                                     />
@@ -176,6 +178,7 @@ export default {
                 value => notEmpty(value),
             ],
             numberRules: [
+                value => notEmpty(value),
                 value => isNumber(value),
                 value => atLeastZero(value),
             ],

--- a/app/src/components/admin-page/product-tab.vue
+++ b/app/src/components/admin-page/product-tab.vue
@@ -186,8 +186,8 @@ export default {
                 id: null,
                 name: '',
                 stock: 0,
-                price: 0.00,
-                bottleDeposit: 0.00,
+                price: null,
+                bottleDeposit: null,
                 tags: [],
                 manufacturerID: null,
             };

--- a/app/src/components/admin-page/topup-modal.vue
+++ b/app/src/components/admin-page/topup-modal.vue
@@ -93,7 +93,7 @@ export default {
     watch: {
         showDialog(value) {
             if (value) {
-                this.amount = 1;
+                this.amount = null;
             }
         },
     },


### PR DESCRIPTION
Remove default values for a newly created item and add a non-empty rule to numbers. 
Makes no sense to have pre-filled zeros on number values while text -fields are empty.

closes #38 